### PR TITLE
Update AuthorizeTransaction.php

### DIFF
--- a/examples/AuthorizeTransaction.php
+++ b/examples/AuthorizeTransaction.php
@@ -1,5 +1,9 @@
 <?php
-require_once '../vendor/autoload.php';
+
+$path = dirname(dirname(dirname(dirname(dirname(__FILE__)))));
+$fileName = $path . "/vendor/autoload.php";
+//echo $fileName;
+require_once $fileName;
 
 
 use Alexandreo\BrasPag;


### PR DESCRIPTION
FIX:

Warning: require_once(../vendor/autoload.php): failed to open stream: No such file or directory in /home/marcio/dados/public_html/test/vendor/alexandreo/bras-pag/examples/AuthorizeTransaction.php on line 2

Fatal error: require_once(): Failed opening required '../vendor/autoload.php' (include_path='.:/usr/share/php') in /home/marcio/dados/public_html/test/vendor/alexandreo/bras-pag/examples/AuthorizeTransaction.php on line 2
